### PR TITLE
feat: implement dynamic model validation with schema support

### DIFF
--- a/note2webapp/forms.py
+++ b/note2webapp/forms.py
@@ -16,7 +16,7 @@ class UploadForm(forms.ModelForm):
 class VersionForm(forms.ModelForm):
     class Meta:
         model = ModelVersion
-        fields = ["model_file", "predict_file", "tag", "category"]
+        fields = ["model_file", "predict_file", "schema_file", "tag", "category"]
 
     def clean_model_file(self):
         file = self.cleaned_data.get("model_file")
@@ -28,6 +28,12 @@ class VersionForm(forms.ModelForm):
         file = self.cleaned_data.get("predict_file")
         if file and not file.name.endswith(".py"):
             raise forms.ValidationError("Only .py files are allowed for Predict File")
+        return file
+    
+    def clean_schema_file(self):
+        file = self.cleaned_data.get("schema_file")
+        if file and not file.name.endswith(".json"):
+            raise forms.ValidationError("Only .json files allowed for schema")
         return file
 
     def clean_tag(self):

--- a/note2webapp/models.py
+++ b/note2webapp/models.py
@@ -44,6 +44,7 @@ class ModelVersion(models.Model):
     upload = models.ForeignKey(ModelUpload, on_delete=models.CASCADE, related_name="versions")
     model_file = models.FileField(upload_to="models/")
     predict_file = models.FileField(upload_to="predict/")
+    schema_file = models.FileField(upload_to="schemas/", blank=True, null=True)  # for test data generation
     tag = models.CharField(max_length=100)
 
     # NEW FIELD

--- a/note2webapp/templates/note2webapp/home.html
+++ b/note2webapp/templates/note2webapp/home.html
@@ -111,6 +111,16 @@
               <p id="predictFileName" class="mt-2 small text-muted">No file chosen</p>
           </div>
 
+          <!-- Schema File Upload -->
+          <div class="mb-4 text-center border rounded p-4 bg-secondary bg-opacity-25">
+              <p>📄 Upload your <b>schema.json</b> file</p>
+              {{ form.schema_file|add_class:"d-none"|attr:"id:id_schema_file" }}
+              <button type="button" class="btn btn-success" onclick="document.getElementById('id_schema_file').click();">
+                  + Add Schema File
+              </button>
+              <p id="schemaFileName" class="mt-2 small text-muted">No file chosen</p>
+          </div>
+
           <!-- Tag -->
           <div class="mb-3">
               <label class="form-label fw-bold">Tag</label>
@@ -142,6 +152,12 @@
   document.getElementById('id_predict_file').addEventListener('change', function() {
       let name = this.files[0] ? this.files[0].name : "No file chosen";
       document.getElementById('predictFileName').innerText = name;
+  });
+  </script>
+  <script>
+  document.getElementById('id_schema_file').addEventListener('change', function() {
+      let name = this.files[0] ? this.files[0].name : "No file chosen";
+      document.getElementById('schemaFileName').innerText = name;
   });
   </script>
   {% endif %}

--- a/note2webapp/utils.py
+++ b/note2webapp/utils.py
@@ -1,13 +1,42 @@
 import importlib.util
 import torch
 import traceback
+import json, os
+
+TYPE_MAP = {
+    "float": float,
+    "int": int,
+    "str": str,
+    "bool": bool
+}
+
+def generate_dummy_input(schema_path):
+    with open(schema_path, "r") as f:
+        schema = json.load(f)
+
+    input_schema = schema.get("input", {})
+    dummy = {}
+    for key, typ in input_schema.items():
+        py_type = TYPE_MAP.get(typ)
+        if py_type == float:
+            dummy[key] = 1.0
+        elif py_type == int:
+            dummy[key] = 42
+        elif py_type == str:
+            dummy[key] = "example"
+        elif py_type == bool:
+            dummy[key] = True
+        else:
+            raise ValueError(f"Unsupported type: {typ}")
+    return dummy, schema.get("output", {})
 
 def validate_model(version):
     try:
-        # Load model file
-        model = torch.load(version.model_file.path, map_location="cpu")
+        # 🔁 Change to directory containing model.pt
+        model_dir = os.path.dirname(version.model_file.path)
+        os.chdir(model_dir)
 
-        # Import predict.py dynamically
+        # ✅ Dynamically import predict.py
         spec = importlib.util.spec_from_file_location("predict", version.predict_file.path)
         module = importlib.util.module_from_spec(spec)
         spec.loader.exec_module(module)
@@ -15,12 +44,27 @@ def validate_model(version):
         if not hasattr(module, "predict"):
             raise Exception("predict() function missing in predict.py")
 
-        # Dummy inference
-        dummy_input = torch.randn(1, 3, 224, 224)
-        _ = module.predict(model, dummy_input)
+        # Load schema + generate dummy input
+        if not version.schema_file:
+            raise Exception("No schema file provided")
+        dummy_input, expected_output = generate_dummy_input(version.schema_file.path)
+
+        # Call predict with ONLY dummy input
+        output = module.predict(dummy_input)
+
+        # Validate output
+        if not isinstance(output, dict):
+            raise Exception("predict() must return a dict")
+
+        for key, typ in expected_output.items():
+            if key not in output:
+                raise Exception(f"Missing key in output: {key}")
+            if not isinstance(output[key], TYPE_MAP.get(typ)):
+                raise Exception(f"Wrong type for '{key}': expected {typ}, got {type(output[key]).__name__}")
 
         version.status = "PASS"
-        version.log = "Validation successful"
+        version.log = f"Validation successful ✅\nInput: {json.dumps(dummy_input)}\nOutput: {json.dumps(output, indent=2)}"
+
     except Exception:
         version.status = "FAIL"
         version.log = traceback.format_exc()


### PR DESCRIPTION
- Added support for model validation via predict.py and model.pt
- Integrated schema.json to define expected input/output structure
- Enabled dummy inference to verify model compatibility
- Stored validation logs and status per model version
- Displayed results (PASS/FAIL) in the dashboard
- [TODO] Implement reupload button for failed validation
- [TODO] Add support for more Model I/O types in note2webapp/utils.py

Closes #13 