### PR TITLE
fix: display model version upload time in user’s local timezone

### DIFF
--- a/note2webapp/templates/note2webapp/model_versions.html
+++ b/note2webapp/templates/note2webapp/model_versions.html
@@ -76,7 +76,7 @@
                             {% endif %}
                         </td>
                         <td class="{% if version.is_deleted %}text-strike{% endif %}">
-                            {{ version.created_at|date:"M d, Y H:i" }}
+                            <span class="utc-time" data-utc="{{ version.created_at|date:'c' }}"></span>
                         </td>
                         <td>
                             {% if version.status == "FAIL" %}
@@ -616,5 +616,26 @@ function getCookie(name) {
     }
     return cookieValue;
 }
+
+// Convert UTC timestamps to local device time
+document.addEventListener("DOMContentLoaded", function() {
+    function formatToLocalTime(utcString) {
+        const date = new Date(utcString);
+        const options = {
+            year: 'numeric',
+            month: 'short',
+            day: 'numeric',
+            hour: '2-digit',
+            minute: '2-digit'
+        };
+        return date.toLocaleString(undefined, options);
+    }
+
+    document.querySelectorAll('.utc-time').forEach(el => {
+        const utc = el.dataset.utc;
+        el.textContent = formatToLocalTime(utc);
+    });
+});
+
 </script>
 {% endblock %}


### PR DESCRIPTION
Model version timestamps were shown in UTC, causing confusion between server and client time zones. This fix adds a JavaScript conversion to render uploaded dates using the user’s local time.

Changes:
- Updated model_versions.html to include data-utc spans
- Added client-side script to convert UTC → local time on page load

No backend logic modified; timestamps are still stored in UTC.

Closes #86 